### PR TITLE
fix: resolve broken-links CI failures

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,2 +1,7 @@
 linkedin.com
 reddit.com
+amazon\.com
+a\.co
+vulnhub\.com
+cyberseclabs\.co\.uk
+.*%7B%7B.*

--- a/_pages/about_einstein.md
+++ b/_pages/about_einstein.md
@@ -1,5 +1,5 @@
 Write your biography here. Tell the world about yourself. Link to your favorite [subreddit](http://reddit.com). You can put a picture in, too. The code is already in, just name your picture `prof_pic.jpg` and put it in the `img/` folder.
 
-Put your address / P.O. box / other info right below your picture. You can also disable any these elements by editing `profile` property of the YAML header of your `_pages/about.md`. Edit `_bibliography/papers.bib` and Jekyll will render your [publications page](/al-folio/publications/) automatically.
+Put your address / P.O. box / other info right below your picture. You can also disable any these elements by editing `profile` property of the YAML header of your `_pages/about.md`. Edit `_bibliography/papers.bib` and Jekyll will render your publications page automatically.
 
 Link to your social media connections, too. This theme is set up to use [Font Awesome icons](https://fontawesome.com/) and [Academicons](https://jpswalsh.github.io/academicons/), like the ones below. Add your Facebook, Twitter, LinkedIn, Google Scholar, or just disable all of them.

--- a/_pages/cyber-podcasts-.md
+++ b/_pages/cyber-podcasts-.md
@@ -60,21 +60,17 @@ Here are some of the **best cybersecurity podcasts** I recommend to stay sharp, 
 <!-- 🔽 Replace placeholder image URLs with actual podcast logos or your brand icons if desired -->
 
 {% assign podcasts = "
-2 Cyber Chicks|https://2cyberchicks.libsyn.com|Conversations with female cybersecurity professionals
 401 Access Denied|https://www.itpro.tv/podcast/401-access-denied|IT security topics explained
 7 Minute Security|https://7ms.us|Short practical security lessons
 8th Layer Insights|https://8thlayerinsights.com|Human side of cybersecurity
 Absolute AppSec|https://absoluteappsec.com|Application security topics
-Adopting Zero Trust|https://adoptingzerotrust.buzzsprout.com|Zero Trust strategies and stories
-Adventures of Alice and Bob|https://adventuresofaliceandbob.com|Security explained simply
 Breaking Down Security|https://brakeingsecurity.com|Security concepts and news
 Click Here|https://clickhereshow.com|Deep dives into security breaches
 Crypto-Gram Security Podcast|https://www.schneier.com/crypto-gram|Bruce Schneier's monthly digest
-Cyber Insecurity|https://www.cyberinsecurity.tv/ | Candid security conversations
+Cyber Insecurity|https://www.cyberinsecurity.tv/|Candid security conversations
 Cyber Security Headlines|https://cisoseries.com/cyber-security-headlines|Daily news briefings
 Cyber Security Sauna|https://blog.f-secure.com/podcast|Interviews with security experts
 Cyber Work|https://www.infosecinstitute.com/podcast|Career development in security
-Cybersecurity Today|https://www.itworldcanada.com/tag/cyber-security-today|Canadian cybersecurity news
 Cyberside Chats|https://cybersidechats.podbean.com|General security topics
 Darknet Diaries|https://darknetdiaries.com|Real stories from the dark side of the Internet
 Defrag This|https://www.ipswitch.com/podcasts|IT and security topics
@@ -82,24 +78,16 @@ H4unt3d Hacker|https://h4unt3dhacker.podbean.com|Interviews with hackers and exp
 Hacker Valley Studio|https://hackervalley.com|Cybersecurity leadership and life
 Hacking Humans|https://thecyberwire.com/podcasts/hacking-humans|Social engineering and scams
 Identity at the Center|https://identityatthecenter.com|Identity and access management
-InfoSec Live|https://infoseclive.com/podcasts|Security community podcasts
-InfoSec Real|https://infosecreal.com|Real-life security experiences
-Life of a CISO|https://www.drmikestefanick.com/life-of-a-ciso|CISO challenges and insights
 Malicious Life|https://malicious.life|History of cybersecurity
 Naked Security Podcast|https://nakedsecurity.sophos.com/category/podcast|Sophos security news
 Open Source Security Podcast|https://opensourcesecuritypodcast.com|Open source security topics
-OWASP Podcast|https://owasp.org/www-podcast|AppSec and OWASP community news
 Risky Business|https://risky.biz|Weekly security news and analysis
-Security in Five|https://securityinfive.libsyn.com|Daily security tips in five minutes
 Security Now|https://twit.tv/shows/security-now|Deep dives into security with Steve Gibson
 Security Weekly|https://www.securityweekly.com|Industry news and interviews
 Simply Cyber|https://www.simplycyber.io|Cyber career and skill development
 Smashing Security|https://www.smashingsecurity.com|Lighthearted take on security news
 Task Force 7|https://taskforce7radio.com|Enterprise cybersecurity topics
-The 443 Security Simplified|https://www.secplicity.org/category/the-443|Simplified security news
-The Cyber Tap|https://thecybertappodcast.libsyn.com|Cybersecurity discussions by Purdue
 The Cyberlaw Podcast|https://www.lawfareblog.com/topic/cyberlaw-podcast|Lawfare's cyberlaw analysis
-The Hacker Chronicles|https://thehackerchronicles.com|Fictional hacker drama series
 The Hacker Mind|https://thehackermind.com|Hacker stories and interviews
 The Privacy, Security, & OSINT Show|https://inteltechniques.com/podcast.html|Privacy and OSINT topics
 The Shared Security Show|https://sharedsecurity.net|Security and privacy for all
@@ -107,7 +95,6 @@ The Shellsharks Podcast|https://shellsharks.com|General cybersecurity podcast
 The Social-Engineer Podcast|https://www.social-engineer.org/podcast|Social engineering insights
 The Virtual CISO Moment|https://anchor.fm/virtualcisomoment|CISO leadership discussions
 Unsupervised Learning|https://danielmiessler.com/podcast|Weekly curated security topics
-We Talk Cyber|https://wetalkcyber.libsyn.com|Conversations with global experts
 What The Shell|https://whattheshellpod.com|General infosec discussions
 " | split: "
 " %}

--- a/_posts/2025-02-19-cybernews0219.md
+++ b/_posts/2025-02-19-cybernews0219.md
@@ -81,7 +81,7 @@ A new campaign targeting educational institutions involves the distribution of w
 
 A new variant of the Snake Keylogger malware is infecting Windows users, particularly in Asia and Europe. This version utilizes the AutoIt scripting language to deploy itself, adding obfuscation layers to evade detection. Once installed, it logs keystrokes, captures screenshots, and steals clipboard data, compromising user credentials and sensitive information.
 
-[Read more](https://www.theregister.com/2025/02/19/new_snake_keylogger_infects_windows/)
+Read more (article link unavailable)
 
 ## Story 9: Venture Capital Firm Insight Partners Suffers Cyberattack
 

--- a/_posts/2025-03-07-cybernews0307.md
+++ b/_posts/2025-03-07-cybernews0307.md
@@ -25,7 +25,7 @@ Experts argue that cybersecurity strategies must shift from an over-reliance on 
 ## Story 2. Researchers Bypass CrowdStrike Falcon Sensor, Exposing Detection Weakness
 
 Security researchers have demonstrated a method to bypass CrowdStrike’s Falcon Sensor, an advanced endpoint detection and response (EDR) tool. The exploit allows attackers to evade detection and execute malicious code undetected. While CrowdStrike is investigating the bypass technique, the findings raise concerns about the effectiveness of security solutions in stopping sophisticated attacks. Experts recommend using multiple layers of security rather than relying on a single detection tool.  
-[Read more here](https://cybersecuritynews.com/researchers-bypassed-crowdstrike-falcon-sensor/)
+Read more (article link unavailable)
 
 ---
 


### PR DESCRIPTION
- Ignore Amazon/a.co links (return 500 to bots, valid for users)
- Ignore vulnhub.com (Cloudflare 522) and cyberseclabs.co.uk (timeout)
- Ignore unrendered Liquid template URLs (%%7B%7B pattern)
- Remove 13 dead podcast entries from cyber-podcasts page
- Fix leftover al-folio template link in about_einstein.md
- Remove 2 dead article links in Feb/Mar 2025 news posts