### PR TITLE
fix(ci): add --root-dir to lychee broken-links-site for v2 compat

### DIFF
--- a/.github/workflows/broken-links-site.yml
+++ b/.github/workflows/broken-links-site.yml
@@ -44,4 +44,4 @@ jobs:
         with:
           fail: true
           # only check local links
-          args: --offline --remap '_site(/?.*)/assets/(.*) _site/assets/$2' --verbose --no-progress '_site/**/*.html'
+          args: --offline --root-dir ${{ github.workspace }}/_site --remap '_site(/?.*)/assets/(.*) _site/assets/$2' --verbose --no-progress '_site/**/*.html'


### PR DESCRIPTION
Lychee v2 requires an absolute --root-dir to resolve root-relative links (href="/foo/") when checking local files in offline mode. v1.9 was lenient about this; the v2.8 bump surfaced ~20k errors across the site. Set root-dir to ${{ github.workspace }}/_site so all root-relative URLs resolve correctly.