### PR TITLE
fix(ci): drop lycheeVersion: latest in broken-links.yml

### DIFF
--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -48,6 +48,5 @@ jobs:
         uses: lycheeverse/lychee-action@v2.8.0
         with:
           fail: true
-          lycheeVersion: latest
           # removed md files that include liquid tags
           args:   --user-agent 'curl/7.54'  --verbose --no-progress --root-dir . --base-url https://djbsec.github.io --accept 200,429,403 --max-retries 0 --exclude-path README.md --exclude-path FAQ.md --exclude-path INSTALL.md --exclude-path CUSTOMIZE.md --exclude-path _pages/404.md --exclude-path _pages/blog.md --exclude-path examples/ --exclude-path lighthouse_results/ '_pages/**/*.md' '_posts/**/*.md'


### PR DESCRIPTION
The lychee-action install step has an upstream bug when lycheeVersion: latest is set: it downloads the tarball but looks for the binary at /home/runner/work/_temp/lychee-download/lychee while the binary is actually at lychee-x86_64-unknown-linux-gnu/lychee inside the extracted directory. Removing lycheeVersion lets the action use its bundled lychee binary, which works correctly.