### PR TITLE
Add tools landing, learning paths, templates, field notes, subscribe CTA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,6 +93,17 @@ jobs:
         run: |
           npm install -g purgecss@8.0.0
           purgecss -c purgecss.config.js
+      - name: Build template PDFs 📄
+        if: github.event_name != 'pull_request'
+        continue-on-error: true
+        run: |
+          npm install -g md-to-pdf@5.2.0
+          mkdir -p _site/assets/pdf/templates
+          for f in _includes/templates/*.md; do
+            [ -f "$f" ] || continue
+            base=$(basename "$f" .md)
+            md-to-pdf "$f" --pdf-options '{"format":"Letter","margin":{"top":"0.75in","right":"0.75in","bottom":"0.75in","left":"0.75in"}}' --dest "_site/assets/pdf/templates/" || echo "PDF gen failed for $f — skipping"
+          done
       - name: Deploy 🚀
         if: github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ _posts/archive
 assets/archive
 .superpowers/
 claude-changes.log
+AGENTS.md

--- a/_config.yml
+++ b/_config.yml
@@ -156,6 +156,9 @@ collections:
   conferences:
     output: true
     permalink: /cybersecurity-calendar/:title/
+  templates:
+    output: true
+    permalink: /templates/:title/
 
 # -----------------------------------------------------------------------------
 # Jekyll settings

--- a/_data/learning_paths.yml
+++ b/_data/learning_paths.yml
@@ -1,0 +1,205 @@
+# Learning paths for /start/. Each path = persona + ordered steps.
+# step.kind: "explained" (article from _explained), "tool" (from /tools/),
+#            "external" (off-site link), "checkpoint" (review milestone).
+# step.url is required for explained/tool/external; optional for checkpoint.
+
+- id: new-to-cyber
+  title: New to Cybersecurity
+  audience: For curious beginners with no prior background.
+  icon: seedling
+  description: >
+    Build a working mental model of how attacks happen and how defenders
+    respond. No tools, no jargon — start here, then branch into a role.
+  goal: Understand the basics; protect your own accounts and devices.
+  duration: ~45 min reading
+  steps:
+    - kind: explained
+      title: The CIA Triad
+      url: /explained/cia-triad/
+      desc: The three security goals every control maps back to.
+    - kind: explained
+      title: Strong Passwords
+      url: /explained/strong-passwords/
+      desc: Why length beats complexity and how attackers crack weak ones.
+    - kind: explained
+      title: Password Managers
+      url: /explained/password-managers/
+      desc: One vault, unique passwords, no reuse.
+    - kind: explained
+      title: Multi-Factor Authentication
+      url: /explained/two-factor-authentication/
+      desc: Even a leaked password should not be enough.
+    - kind: explained
+      title: Phishing & Social Engineering
+      url: /explained/social-engineering/
+      desc: Most breaches start with a person, not a zero-day.
+    - kind: explained
+      title: Malware
+      url: /explained/malware/
+      desc: Viruses, worms, trojans — what they are and how they spread.
+    - kind: explained
+      title: Ransomware
+      url: /explained/ransomware/
+      desc: The dominant criminal threat to small organizations today.
+    - kind: explained
+      title: Backups
+      url: /explained/backups/
+      desc: The single most cost-effective ransomware control.
+    - kind: checkpoint
+      title: Personal Hardening Checklist
+      desc: Pick a password manager, turn on MFA on email + bank + work, set up backups for one important folder. Then continue.
+
+- id: blue-team-analyst
+  title: Blue Team Analyst
+  audience: For aspiring SOC analysts or working defenders.
+  icon: shield-check
+  description: >
+    Move from concepts to daily operations: vulnerability triage, IOC
+    research, log review, and incident response.
+  goal: Be able to triage a CVE, look up an IP, and read a hash result.
+  duration: ~90 min + tool practice
+  steps:
+    - kind: explained
+      title: CVEs & CVSS Scoring
+      url: /explained/cve-cvss/
+      desc: How vulnerabilities get IDs and how severity is scored.
+    - kind: explained
+      title: EPSS — Exploit Likelihood
+      url: /explained/epss/
+      desc: Why CVSS alone is not enough and where EPSS fits.
+    - kind: tool
+      title: EPSS Scanner
+      url: /epss/
+      desc: Look up a real CVE — try CVE-2021-44228 (Log4Shell).
+    - kind: explained
+      title: Patch Management
+      url: /explained/patch-management/
+      desc: Turn vulnerability data into a patching cadence.
+    - kind: explained
+      title: Attack Surface
+      url: /explained/attack-surface/
+      desc: What you expose is what you have to defend.
+    - kind: explained
+      title: Incident Response
+      url: /explained/incident-response/
+      desc: The PICERL lifecycle — Prepare, Identify, Contain, Eradicate, Recover, Lessons.
+    - kind: tool
+      title: IP Reputation
+      url: /tools/ip-reputation/
+      desc: Pivot a suspicious IP across multiple intel sources.
+    - kind: tool
+      title: Hash Lookup
+      url: /tools/hash-lookup/
+      desc: Identify whether a file hash is known-good (NSRL) or known-malicious.
+    - kind: explained
+      title: OSINT
+      url: /explained/osint/
+      desc: Open-source intelligence techniques for analysts.
+    - kind: explained
+      title: Red Team vs Blue Team
+      url: /explained/red-blue-team/
+      desc: How offense and defense work together (purple teaming).
+    - kind: tool
+      title: Blue Team Hub
+      url: /blue-team/
+      desc: Bookmark this — it is your daily toolkit landing page.
+
+- id: it-leader
+  title: IT Leader
+  audience: For directors, managers, and architects shaping security strategy.
+  icon: chess-king
+  description: >
+    Frameworks and architectural primitives for building a defensible
+    program. Light on tools, heavy on principles and tradeoffs.
+  goal: Speak fluently about zero trust, segmentation, and supply chain risk.
+  duration: ~70 min reading
+  steps:
+    - kind: explained
+      title: The CIA Triad
+      url: /explained/cia-triad/
+      desc: The vocabulary every policy and control maps to.
+    - kind: explained
+      title: Least Privilege
+      url: /explained/least-privilege/
+      desc: The single most leveraged architectural control.
+    - kind: explained
+      title: Zero Trust
+      url: /explained/zero-trust/
+      desc: Never trust, always verify — and what that means in practice.
+    - kind: explained
+      title: Network Segmentation
+      url: /explained/network-segmentation/
+      desc: Containing blast radius when (not if) something gets in.
+    - kind: explained
+      title: Multi-Factor Authentication
+      url: /explained/mfa-apps/
+      desc: Choosing app-based MFA over SMS — why and how to roll out.
+    - kind: explained
+      title: Supply Chain Attacks
+      url: /explained/supply-chain-attacks/
+      desc: SolarWinds-class risk and how to reason about vendor dependencies.
+    - kind: explained
+      title: Patch Management
+      url: /explained/patch-management/
+      desc: The operational reality behind a "patched" environment.
+    - kind: explained
+      title: Incident Response
+      url: /explained/incident-response/
+      desc: Tabletop exercise material for your leadership team.
+    - kind: explained
+      title: Backups
+      url: /explained/backups/
+      desc: Your final, tested control against ransomware.
+    - kind: checkpoint
+      title: Strategy Review
+      desc: Map each principle to one control already in place and one gap. That is your next quarter's roadmap.
+
+- id: small-business
+  title: Small Business Owner
+  audience: For owners and operators of teams under ~50 people.
+  icon: building-store
+  description: >
+    Get the highest-leverage controls in place without a full-time
+    security team. Focused on email, accounts, and recovery.
+  goal: Reach a defensible baseline you can re-audit annually.
+  duration: ~50 min reading + 1 hour setup
+  steps:
+    - kind: explained
+      title: Strong Passwords
+      url: /explained/strong-passwords/
+      desc: "Issue: most breaches start with credential reuse."
+    - kind: explained
+      title: Password Managers
+      url: /explained/password-managers/
+      desc: Pick one. Roll it to the team. Done.
+    - kind: explained
+      title: Multi-Factor Authentication (App-Based)
+      url: /explained/mfa-apps/
+      desc: Free, fast, blocks ~99% of credential-stuffing attempts.
+    - kind: explained
+      title: Email Spoofing
+      url: /explained/emailspoofing/
+      desc: SPF, DKIM, DMARC — the cheapest brand-protection wins.
+    - kind: explained
+      title: Business Email Compromise
+      url: /explained/business-email-compromise/
+      desc: Wire-fraud loss vector — train staff and add an out-of-band check.
+    - kind: explained
+      title: Ransomware
+      url: /explained/ransomware/
+      desc: Worst-case scenario you must plan for.
+    - kind: explained
+      title: Backups
+      url: /explained/backups/
+      desc: Tested, off-site, immutable if possible.
+    - kind: explained
+      title: Social Engineering
+      url: /explained/social-engineering/
+      desc: Brief your team — a 30-minute talk pays for itself.
+    - kind: explained
+      title: Patch Management
+      url: /explained/patch-management/
+      desc: Auto-update everything you can. Track the rest in a spreadsheet.
+    - kind: checkpoint
+      title: Annual Re-Audit
+      desc: Schedule the next review for one year out. The threat landscape moves; your baseline must too.

--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -1,0 +1,100 @@
+# Tools landing page data — drives _pages/tools.md grouping.
+# Each group renders as a section with .djb-card tiles.
+
+- group: Vulnerability Management
+  slug: vuln-mgmt
+  description: Triage and prioritize vulnerabilities by real-world exploit likelihood.
+  icon: shield-half-filled
+  tools:
+    - name: EPSS Scanner
+      url: /epss/
+      description: Look up Exploit Prediction Scoring System (EPSS) scores for any CVE, with 30-day history and CISA KEV cross-reference.
+      action: Launch
+      status: active
+
+- group: Web Security
+  slug: web-security
+  description: Inspect live web applications for missing protections.
+  icon: lock
+  tools:
+    - name: Header Analyzer
+      url: /tools/header-analyzer/
+      description: Inspect HTTP security headers and surface missing protections (CSP, HSTS, X-Frame-Options, Permissions-Policy).
+      action: Launch
+      status: active
+
+- group: OSINT & Intel
+  slug: osint
+  description: Reputation, attribution, and adversary research from open sources.
+  icon: world-search
+  tools:
+    - name: IP Reputation
+      url: /tools/ip-reputation/
+      description: Query IPs against AbuseIPDB, GreyNoise, and other threat-intel sources in one shot.
+      action: Launch
+      status: active
+    - name: OSINT Search
+      url: /cybersearch/
+      description: Curated OSINT and cybersecurity-focused search engines for threat intelligence research.
+      action: Open
+      status: active
+    - name: MITRE ATT&CK
+      url: https://attack.mitre.org/
+      description: Globally accessible knowledge base of adversary tactics, techniques, and procedures.
+      action: Open
+      external: true
+      status: active
+
+- group: Forensics & Analysis
+  slug: forensics
+  description: Identify files, hashes, and indicators of compromise.
+  icon: fingerprint
+  tools:
+    - name: Hash Lookup
+      url: /tools/hash-lookup/
+      description: Check MD5/SHA-1/SHA-256 hashes against CIRCL Hashlookup (NSRL known-good and known-malicious).
+      action: Launch
+      status: active
+    - name: Log Analyzer
+      url: "#"
+      description: Parse common log formats (Apache, Nginx, syslog, JSON-lines) to surface suspicious patterns and IOCs.
+      action: In development
+      status: planned
+
+- group: Threat Mapping
+  slug: maps
+  description: Real-time threat telemetry and global attack visualization.
+  icon: map-2
+  tools:
+    - name: Threat Maps
+      url: /maps/
+      description: Curated set of live threat maps from major vendors and security feeds.
+      action: Open
+      status: active
+
+- group: AI & Prompt Engineering
+  slug: ai
+  description: Prompts and AI tooling for daily security work.
+  icon: sparkles
+  tools:
+    - name: AI Tools & Prompts
+      url: /ai-tools-prompts/
+      description: Hand-tuned prompts for ChatGPT and Copilot covering policy drafting, log analysis, and incident triage.
+      action: Open
+      status: active
+
+- group: Hubs
+  slug: hubs
+  description: Themed landing pages that group tools by audience.
+  icon: layout-grid
+  tools:
+    - name: Blue Team
+      url: /blue-team/
+      description: Defender-focused tool index with quick-start workflow.
+      action: Open
+      status: active
+    - name: Red Team
+      url: /red-team/
+      description: Offensive testing reference (read-only resource list).
+      action: Open
+      status: active

--- a/_includes/subscribe-cta.html
+++ b/_includes/subscribe-cta.html
@@ -1,0 +1,39 @@
+<section class="subscribe-cta" aria-labelledby="subscribe-cta-title">
+  <div>
+    <h3 class="subscribe-cta__title" id="subscribe-cta-title">Stay current</h3>
+    <p class="subscribe-cta__desc">Daily CyberNews briefings, slow-burn Field Notes, and new tools. Pick the channel that fits.</p>
+  </div>
+  <div class="subscribe-cta__actions">
+    <a class="btn btn-sm btn-djb-secondary" href="{{ '/feed.xml' | relative_url }}" target="_blank" rel="noopener noreferrer">
+      <i class="fa-solid fa-square-rss" aria-hidden="true"></i> RSS
+    </a>
+    {% if site.data.socials.linkedin_username %}
+    <a class="btn btn-sm btn-djb-secondary" href="https://www.linkedin.com/in/{{ site.data.socials.linkedin_username }}" target="_blank" rel="noopener noreferrer">
+      <i class="fa-brands fa-linkedin" aria-hidden="true"></i> LinkedIn
+    </a>
+    {% endif %}
+    {% if site.data.socials.github_username %}
+    <a class="btn btn-sm btn-djb-secondary" href="https://github.com/{{ site.data.socials.github_username }}" target="_blank" rel="noopener noreferrer">
+      <i class="fa-brands fa-github" aria-hidden="true"></i> GitHub
+    </a>
+    {% endif %}
+    {% if site.data.socials.youtube_id %}
+    <a class="btn btn-sm btn-djb-secondary" href="https://youtube.com/@{{ site.data.socials.youtube_id }}" target="_blank" rel="noopener noreferrer">
+      <i class="fa-brands fa-youtube" aria-hidden="true"></i> YouTube
+    </a>
+    {% endif %}
+    {% if site.data.socials.tiktok_username %}
+    <a class="btn btn-sm btn-djb-secondary" href="https://www.tiktok.com/@{{ site.data.socials.tiktok_username }}" target="_blank" rel="noopener noreferrer">
+      <i class="fa-brands fa-tiktok" aria-hidden="true"></i> TikTok
+    </a>
+    {% endif %}
+  </div>
+
+  {% if site.newsletter.enabled and site.newsletter.endpoint %}
+  <form class="subscribe-cta__newsletter" method="POST" action="{{ site.newsletter.endpoint }}" target="_blank" rel="noopener noreferrer">
+    <label for="subscribe-cta-email" class="sr-only">Email address</label>
+    <input type="email" id="subscribe-cta-email" name="email" placeholder="you@example.com" required autocomplete="email">
+    <button type="submit" class="btn btn-sm btn-djb-secondary">Subscribe &rarr;</button>
+  </form>
+  {% endif %}
+</section>

--- a/_includes/templates/executive-cyber-briefing.md
+++ b/_includes/templates/executive-cyber-briefing.md
@@ -1,0 +1,82 @@
+# Executive Cyber Briefing Template
+
+A monthly or quarterly report template for non-technical executives, board members, or business owners. Aim for 2 pages. Replace the bracketed prompts with current state.
+
+---
+
+## 1. One-line summary (TL;DR)
+
+> [Current posture in one sentence. Example: "Posture is stable; one high-severity issue under remediation; phishing volume up 18% this month."]
+
+## 2. Risk dashboard
+
+| Area | Status | Change vs last period | Notes |
+|------|--------|----------------------|-------|
+| Vulnerability remediation | 🟢 / 🟡 / 🔴 | ▲ / ▬ / ▼ | [Open critical CVEs aging > SLA] |
+| Identity & access | 🟢 / 🟡 / 🔴 | ▲ / ▬ / ▼ | [MFA coverage %] |
+| Endpoint protection | 🟢 / 🟡 / 🔴 | ▲ / ▬ / ▼ | [EDR coverage, last 30d incidents] |
+| Email security | 🟢 / 🟡 / 🔴 | ▲ / ▬ / ▼ | [Phishing reports, BEC attempts] |
+| Backups & recovery | 🟢 / 🟡 / 🔴 | ▲ / ▬ / ▼ | [Last successful restore test] |
+| Third-party / vendor | 🟢 / 🟡 / 🔴 | ▲ / ▬ / ▼ | [SOC 2 expirations, new vendors] |
+
+🟢 within tolerance · 🟡 watch · 🔴 action required
+
+## 3. What changed this period
+
+**Improvements**
+- [Concrete win, e.g., "Rolled out app-based MFA to remaining 12% of staff"]
+- [Concrete win]
+
+**Setbacks or new risks**
+- [Issue + business impact + plan + ETA]
+- [Issue + business impact + plan + ETA]
+
+## 4. Incidents
+
+| Date | Severity | Summary | Status |
+|------|----------|---------|--------|
+| [YYYY-MM-DD] | [Low/Med/High/Crit] | [One sentence] | [Open / Contained / Closed] |
+
+If zero incidents: state that explicitly. Boards distrust silence.
+
+## 5. Threat landscape (external)
+
+Two or three items relevant to *our* industry, vendors, or geography. Avoid generic news.
+
+- **[Threat or trend]** — [What it means for us specifically. What we are doing about it.]
+- **[Threat or trend]** — [Same.]
+
+## 6. Decisions requested
+
+If nothing is needed: say so. Otherwise:
+
+- [ ] **Decision:** [What you need approved] — **Cost:** [$ or FTE] — **Impact if no:** [What breaks or stalls]
+- [ ] **Decision:** ...
+
+## 7. Spend snapshot
+
+| Line item | Budget | Spent YTD | Forecast variance |
+|-----------|--------|-----------|-------------------|
+| Tools & subscriptions | | | |
+| Headcount | | | |
+| Training & certifications | | | |
+| Incident response retainer | | | |
+| Insurance (cyber) | | | |
+
+## 8. Next quarter focus
+
+Three items, not ten. Each item = title + outcome + owner + target date.
+
+1. **[Initiative]** — [Outcome statement] — [Owner] — [Date]
+2. ...
+3. ...
+
+---
+
+## Tone notes (delete before sending)
+
+- Use plain English. "Critical CVE on Fortinet edge" → "Vendor-reported flaw on our perimeter firewall, patch in next 48h."
+- Quantify whenever possible. "We blocked 14,000 phishing emails this month, up from 11,500 last month."
+- Don't bury bad news. Lead with it, then the plan.
+- Map every spend item to a risk it reduces. If you can't, question the spend.
+- Color in dashboards is for at-a-glance; keep one-line annotations explaining the color.

--- a/_includes/templates/incident-response-checklist.md
+++ b/_includes/templates/incident-response-checklist.md
@@ -1,0 +1,79 @@
+# Incident Response Checklist
+
+A working checklist based on the SANS / NIST PICERL lifecycle. Use this in real-time during an incident, or as a tabletop guide.
+
+## 1. Prepare (before anything happens)
+
+- [ ] On-call rotation documented; primary + backup names known
+- [ ] Comms tree: who to call (legal, exec, PR, insurance, MSSP, IR retainer)
+- [ ] Out-of-band comms channel ready (Signal group, separate Slack workspace) — assume primary is compromised
+- [ ] Decision-tree authority: who can authorize containment that takes services offline?
+- [ ] Logs centralized and at least 90 days deep
+- [ ] Recent backup test: when was the last successful restore drill?
+- [ ] IR retainer or hotline number on file
+
+## 2. Identify
+
+- [ ] Source of detection logged (alert, user report, third party, threat-intel feed)
+- [ ] Initial timestamp recorded (UTC)
+- [ ] Affected systems enumerated: hostname, IP, owner, criticality
+- [ ] Indicator of Compromise (IOC) noted: file hash, IP, domain, behavior
+- [ ] Severity assigned (Low / Med / High / Critical) — re-evaluate hourly
+- [ ] Incident ticket opened; ticket ID broadcast to responders
+- [ ] Initial scoping question: data exfil, destructive, persistence, or recon?
+
+## 3. Contain
+
+Short-term:
+
+- [ ] Isolate affected hosts (network quarantine, not power-off — preserve volatile evidence)
+- [ ] Disable compromised credentials (rotate, revoke MFA tokens, kill active sessions)
+- [ ] Block known IOCs at perimeter (firewall, DNS, EDR)
+- [ ] Take memory + disk image of at least one affected host before reboot
+
+Long-term:
+
+- [ ] Patch / reconfigure to prevent re-entry on the same vector
+- [ ] Increase logging and monitoring on adjacent systems
+- [ ] Push EDR / IDS rule updates derived from observed IOCs
+
+## 4. Eradicate
+
+- [ ] Remove malware (re-image is safer than clean — clean only if you're certain)
+- [ ] Reset all credentials with potential exposure
+- [ ] Rotate any leaked secrets (API keys, certificates, service accounts)
+- [ ] Verify persistence mechanisms removed: scheduled tasks, services, registry run keys, web shells, SSH keys, cron jobs
+
+## 5. Recover
+
+- [ ] Restore from clean backup (verified-clean — confirm pre-incident timestamp)
+- [ ] Phased return to production (canary first, then full)
+- [ ] Heightened monitoring for at least 30 days
+- [ ] Confirm normal business function with affected business owners
+
+## 6. Lessons Learned (within 2 weeks)
+
+- [ ] Post-incident review meeting scheduled
+- [ ] Timeline document: what we knew when, what we did when
+- [ ] Root cause: technical AND organizational
+- [ ] Detection gap: would we catch this faster next time? What instrumentation is missing?
+- [ ] Action items logged in a tracker — owner + date for each
+- [ ] Controls / playbook updates committed
+- [ ] Tabletop scenario drafted from the incident for next training cycle
+
+## Severity Quick Reference
+
+| Level | Examples | Response Time |
+|-------|----------|---------------|
+| Critical | Data exfil confirmed; ransomware spreading; production down | Immediate, all hands |
+| High | Single-host compromise; phishing with credential theft | < 1 hour |
+| Medium | Suspicious activity, no confirmed compromise | < 4 hours |
+| Low | Failed exploit attempts; benign anomaly | Next business day |
+
+## Communication Templates
+
+**Internal first message:**
+> We are investigating a potential security incident affecting [systems]. The incident ticket is [ID]. Please [specific instruction — e.g., do not log into X]. Updates every 30 minutes.
+
+**Hold-line (don't have facts yet):**
+> We are aware of [event]. We are currently investigating. We will share verified details as we have them. Avoid speculating internally or externally until we confirm.

--- a/_includes/templates/mfa-rollout-checklist.md
+++ b/_includes/templates/mfa-rollout-checklist.md
@@ -1,0 +1,77 @@
+# MFA Rollout Checklist
+
+Multi-factor authentication is the single highest-ROI control for most organizations. This checklist takes you from "MFA on a few admin accounts" to "MFA on every authentication path that matters."
+
+## Phase 0 — Pre-flight
+
+- [ ] Inventory all authentication systems (IdP, VPN, email, finance, HR, code repo, cloud consoles, RDP/SSH gateways, customer-facing apps with admin functions)
+- [ ] Identify dependencies: which systems federate to your IdP? Which are standalone?
+- [ ] Choose factor types in priority order:
+  1. **FIDO2 / WebAuthn (security keys, platform passkeys)** — phishing-resistant, ideal for admins
+  2. **App-based TOTP / push (Authy, Microsoft Authenticator, Duo, Okta Verify)** — strong, low friction
+  3. **SMS / email OTP** — only as fallback; vulnerable to SIM swap
+- [ ] Pilot group selected (~10% of users, mix of technical and non-technical)
+- [ ] Communications plan drafted: announcement, how-to, help-desk macro
+- [ ] Help desk staffed for first-week spike
+- [ ] Recovery / backup process defined (admin-assisted reset, recovery codes)
+- [ ] Lost-device procedure documented
+
+## Phase 1 — Privileged accounts (week 1)
+
+Scope: domain admins, root/sudo on prod, cloud admins, security team, finance approvers, anyone with `*` permissions anywhere.
+
+- [ ] Hardware security keys procured (YubiKey 5 or equivalent — 2 per admin: primary + backup)
+- [ ] Recovery codes generated, printed, sealed in tamper-evident envelopes, stored in safe
+- [ ] FIDO2 enforced on IdP for privileged groups
+- [ ] Break-glass account documented separately (paper, in safe; not in password manager that could be locked out)
+- [ ] Audit log review: any admin auth that bypassed MFA in the last 30 days?
+
+## Phase 2 — Email and IdP for all users (weeks 2–3)
+
+- [ ] Enrollment self-service portal published
+- [ ] Deadline set (~14 days from announcement)
+- [ ] Daily report of unenrolled users to managers
+- [ ] Conditional access: enforce MFA on all sign-ins; allow exceptions only with documented business reason and expiry date
+- [ ] Legacy / basic auth disabled on email (single biggest BEC mitigation)
+- [ ] OAuth tokens / app passwords audited; revoke unused
+
+## Phase 3 — VPN and remote access (week 4)
+
+- [ ] VPN client integrated with IdP (so MFA flows through)
+- [ ] RDP / SSH jump hosts behind MFA-protected gateway
+- [ ] No direct internet exposure of management interfaces (admin panels, jump hosts)
+
+## Phase 4 — Business apps (weeks 5–8)
+
+For each SaaS / line-of-business app:
+
+- [ ] SSO via IdP (preferred — inherits MFA)
+- [ ] If no SSO: app-native MFA enabled and enforced
+- [ ] If neither: document the gap, set a deprecation or migration date
+
+## Phase 5 — Customer-facing (if applicable)
+
+- [ ] Optional MFA enabled for end users
+- [ ] Required MFA for any customer with elevated permissions (admin role, financial actions)
+- [ ] Risk-based MFA challenges: new device, geographic anomaly, high-value action
+
+## Verification
+
+- [ ] Run a phishing simulation against a small set of users; confirm credentials alone fail without MFA
+- [ ] Confirm reporting dashboard shows enrollment % per group
+- [ ] Confirm break-glass works (test in pre-prod if possible)
+
+## Common pitfalls
+
+- **SMS for admins:** SIM-swap is real. Use FIDO2 for anyone with privileged access.
+- **No backup factor:** every user needs at least 2 factors registered, or recovery becomes a help-desk nightmare.
+- **Push fatigue:** number-matching on push apps prevents accidental approval. Turn it on if your app supports it.
+- **Service accounts:** never put a human's MFA on a service account. Use proper machine identity (cert, managed identity, OIDC).
+- **Legacy protocols:** SMTP basic auth, IMAP, POP3, NTLM, LDAP simple bind — disable wholesale, exception by exception.
+
+## Maintenance
+
+- [ ] Quarterly review of MFA exceptions
+- [ ] Quarterly review of users with no MFA factors registered
+- [ ] Annual replacement / inventory of hardware keys
+- [ ] Annual phishing simulation including MFA-bypass scenarios (consent phishing, push fatigue)

--- a/_includes/templates/security-headers-checklist.md
+++ b/_includes/templates/security-headers-checklist.md
@@ -1,0 +1,101 @@
+# HTTP Security Headers Checklist
+
+Quick-reference for production web applications. Run the [Header Analyzer](/tools/header-analyzer/) tool against your site to confirm.
+
+## Required (high impact, low effort)
+
+### Strict-Transport-Security (HSTS)
+
+```
+Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+```
+
+- [ ] `max-age` is at least one year (31536000 seconds)
+- [ ] `includeSubDomains` set if all subdomains are HTTPS
+- [ ] `preload` directive set and site submitted to hstspreload.org (only after first two confirmed)
+
+### Content-Security-Policy (CSP)
+
+```
+Content-Security-Policy: default-src 'self'; script-src 'self' 'nonce-RANDOM'; style-src 'self'; img-src 'self' data: https:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'
+```
+
+- [ ] `default-src 'self'` baseline
+- [ ] No `'unsafe-inline'` for `script-src`; use nonces or hashes
+- [ ] `object-src 'none'` (kills Flash / legacy plugin attacks)
+- [ ] `frame-ancestors 'none'` (replaces X-Frame-Options)
+- [ ] CSP report-uri or report-to configured for monitoring
+
+### X-Content-Type-Options
+
+```
+X-Content-Type-Options: nosniff
+```
+
+- [ ] Set on every response. No exceptions.
+
+### Referrer-Policy
+
+```
+Referrer-Policy: strict-origin-when-cross-origin
+```
+
+- [ ] Default `strict-origin-when-cross-origin` is safe for most apps
+- [ ] Use `no-referrer` if your app must not leak Referer at all
+
+### Permissions-Policy
+
+```
+Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=()
+```
+
+- [ ] Disable browser features the app does not use
+- [ ] `interest-cohort=()` opts out of FLoC-style tracking (legacy but cheap)
+
+## Cookie Flags
+
+For every Set-Cookie:
+
+- [ ] `Secure` — HTTPS-only
+- [ ] `HttpOnly` — not readable by JavaScript (for session/auth cookies)
+- [ ] `SameSite=Lax` minimum; `SameSite=Strict` if cross-site links don't need session
+- [ ] `__Host-` prefix on session cookies (binds to exact origin, requires Secure + Path=/)
+
+## Headers to REMOVE
+
+- [ ] `Server` — strips version disclosure (e.g., `Server: Apache/2.4.41`)
+- [ ] `X-Powered-By` — strips backend disclosure (e.g., `X-Powered-By: PHP/7.4.3`)
+- [ ] `X-AspNet-Version`, `X-AspNetMvc-Version`
+- [ ] `X-Generator` if it leaks framework version
+
+## Legacy / Deprecated (set if needed for old browsers)
+
+- [ ] `X-Frame-Options: DENY` — only for old browsers; CSP `frame-ancestors` supersedes
+- [ ] `X-XSS-Protection: 0` — explicitly disable; modern advice is to OFF the header (it caused vulns)
+
+## CORS (only if your app needs it)
+
+- [ ] `Access-Control-Allow-Origin` is **never** `*` for authenticated APIs
+- [ ] Allow-list specific origins
+- [ ] `Access-Control-Allow-Credentials: true` only with explicit origin (not wildcard)
+- [ ] `Access-Control-Max-Age` set to limit preflight chatter
+
+## Verification Workflow
+
+1. Deploy headers in **report-only** mode where supported (`Content-Security-Policy-Report-Only`)
+2. Watch reports for 1–2 weeks; tighten policy
+3. Promote to enforcing mode
+4. Re-test with [Header Analyzer](/tools/header-analyzer/) and Mozilla Observatory
+5. Document baseline; any future deviation requires a ticket
+
+## Score Targets
+
+| Tool | Minimum | Target |
+|------|---------|--------|
+| Mozilla Observatory | B+ | A+ |
+| securityheaders.com | A | A+ |
+| Header Analyzer (this site) | All required headers present | All required + no version disclosure |
+
+---
+
+**Reminder:** these headers do not replace input validation, output encoding, authentication, or authorization. They are defense-in-depth. Treat them as the cheapest 10% you must always have set.

--- a/_includes/templates/vulnerability-triage-worksheet.md
+++ b/_includes/templates/vulnerability-triage-worksheet.md
@@ -1,0 +1,74 @@
+# Vulnerability Triage Worksheet
+
+Use this when a new CVE shows up in scanner results, news, or vendor advisory. The goal is to move from "we have 4,000 CVEs" to "we are patching these 12 first" in under 30 minutes per item.
+
+## Core Identifiers
+
+- **CVE ID:** ____________________
+- **Vendor / Product:** ____________________
+- **Affected Versions:** ____________________
+- **Disclosed:** ____________________
+- **Vendor Patch Available?** ☐ Yes ☐ No ☐ Mitigation only
+
+## Severity Inputs
+
+| Source | Score | Notes |
+|--------|-------|-------|
+| CVSS v3.1 base | / 10 | |
+| CVSS v3.1 environmental | / 10 | Adjusted for our context |
+| EPSS (likelihood %) | % | First.org — refresh quarterly |
+| CISA KEV listed? | ☐ Yes ☐ No | If Yes, treat as critical regardless of CVSS |
+
+## Exposure Questions
+
+1. **Is the affected product running in our environment?**
+   ☐ Yes — count: ____   ☐ No   ☐ Unknown
+2. **Is it internet-facing?** ☐ Yes ☐ No ☐ Partially
+3. **Does the vulnerable feature/endpoint run in our deployment?**
+   (Many CVEs apply only when a specific module/option is enabled.)
+4. **Is authentication required to exploit?** ☐ Pre-auth ☐ Auth-required ☐ Local only
+5. **Does the affected system process or store sensitive data?** ☐ Yes ☐ No
+6. **Is there a working public exploit?** ☐ POC ☐ Weaponized ☐ None known
+
+## Compensating Controls Already in Place
+
+- [ ] WAF rule blocks the attack pattern
+- [ ] Network segmentation limits blast radius
+- [ ] EDR detects the post-exploit behavior
+- [ ] IDS/IPS signature deployed
+- [ ] Vendor mitigation applied (config change, feature disable)
+
+## Triage Decision Matrix
+
+| Internet-facing | KEV / Active exploit | Auth | Decision |
+|---|---|---|---|
+| Yes | Yes | Pre-auth | **Patch within 24h, emergency change window** |
+| Yes | No | Pre-auth | Patch within 7 days |
+| Yes | Yes | Auth | Patch within 7 days |
+| No | Yes | Pre-auth | Patch within 14 days |
+| No | No | Any | Patch in next monthly cycle |
+| Any | EPSS > 50% | Any | Bump priority by one tier |
+
+## Action Plan
+
+- [ ] **Patch:** scheduled date ____________________
+- [ ] **Mitigate (interim):** control: ____________________ effective date: __________
+- [ ] **Accept risk:** rationale, expiration date, sign-off: ____________________
+- [ ] **Defer:** justification + revisit date: ____________________
+
+## Verification
+
+- [ ] Patch deployed and tested in non-prod
+- [ ] Asset inventory updated; affected version no longer present
+- [ ] Re-scan confirms remediation
+- [ ] Detection rule deployed in case the vector re-emerges
+
+## Communication
+
+- Owner: ____________________
+- Stakeholders notified: ☐ App team  ☐ Risk / Compliance  ☐ Exec
+- Ticket / change record: ____________________
+
+---
+
+**Quick math reminder:** CVSS measures *severity if exploited*. EPSS measures *likelihood of exploitation in the wild*. CISA KEV says *we already have evidence of exploitation*. A CVSS 9.8 with EPSS 0.5% and not in KEV is rarely the most urgent thing on your queue. A CVSS 6.5 in KEV with a public weaponized exploit, on an internet-facing host, often is.

--- a/_layouts/home.liquid
+++ b/_layouts/home.liquid
@@ -4,6 +4,7 @@ layout: default
 {% include home-hero.html %}
 {% include home-cards.html %}
 {% include home-conferences.html %}
+{% include subscribe-cta.html %}
 
 <footer class="home-footer" role="contentinfo">
   <div class="home-footer__inner">

--- a/_pages/cybernews.md
+++ b/_pages/cybernews.md
@@ -3,7 +3,7 @@ layout: default
 permalink: /cybernews/
 title: CyberNews
 nav: true
-nav_order: 2
+nav_order: 3
 pagination:
   enabled: true
   collection: posts
@@ -204,5 +204,7 @@ pagination:
 {% if page.pagination.enabled %}
 {% include pagination.liquid %}
 {% endif %}
+
+{% include subscribe-cta.html %}
 
 </div>

--- a/_pages/cybersecurity-calendar.md
+++ b/_pages/cybersecurity-calendar.md
@@ -4,7 +4,7 @@ title: Calendar
 permalink: /cybersecurity-calendar/
 description: "US cybersecurity conferences for 2026 — dates, locations, and travel cost estimates from Houston (HOU)."
 nav: true
-nav_order: 2
+nav_order: 6
 ---
 
 <div class="row justify-content-center">

--- a/_pages/dropdown.md
+++ b/_pages/dropdown.md
@@ -2,11 +2,13 @@
 layout: page
 title: Learn
 nav: true
-nav_order: 4
+nav_order: 5
 dropdown: true
 children:
   - title: Cybersecurity Explained
     permalink: /explained/
+  - title: Templates
+    permalink: /templates/
   - title: Repositories
     permalink: /repositories/
   - title: divider

--- a/_pages/field-notes.md
+++ b/_pages/field-notes.md
@@ -1,0 +1,57 @@
+---
+layout: default
+permalink: /field-notes/
+title: Field Notes
+description: Practitioner-judgment posts on how cybersecurity actually plays out in small teams and small organizations.
+nav: false
+---
+
+<div class="post">
+
+<div class="news-masthead">
+  <div class="news-masthead-inner">
+    <div class="news-masthead-title">
+      <span class="news-accent-line"></span>
+      <h1>Field Notes</h1>
+      <span class="news-divider">|</span>
+      <p class="news-tagline">Judgment calls from real engagements</p>
+    </div>
+  </div>
+</div>
+
+<p class="learn-intro" style="max-width: 760px; margin: 1.5rem auto 2rem;">CyberNews tracks the daily threat landscape. <strong>Field Notes</strong> is the opposite — opinionated, slow-burn posts on how cybersecurity actually plays out when you are running a two-person IT team or starting a security program from scratch. Less news, more judgment.</p>
+
+{% assign field_notes = site.posts | where: "categories", "Field Notes" | sort: "date" | reverse %}
+
+{% if field_notes.size == 0 %}
+<p class="learn-intro" style="text-align: center;">No field notes yet — check back soon.</p>
+{% else %}
+
+<div class="news-grid">
+{% for post in field_notes %}
+{% assign read_time = post.content | number_of_words | divided_by: 180 | plus: 1 %}
+<div class="news-card">
+{% if post.thumbnail %}<div class="news-card-img"><img src="{{ post.thumbnail | relative_url }}" alt="{{ post.title }}"></div>{% endif %}
+<div class="news-card-body">
+<span class="news-badge news-badge--cat">Field Notes</span>
+{% if post.tags and post.tags.size > 0 %}
+  {% for tag in post.tags %}
+    <a class="news-badge news-badge--tag" href="{{ tag | slugify | prepend: '/cybernews/tag/' | relative_url }}" onclick="event.stopPropagation()"><i class="fa-solid fa-hashtag fa-xs"></i> {{ tag }}</a>
+  {% endfor %}
+{% endif %}
+<h3 class="news-card-title">{{ post.title }}</h3>
+{% if post.description %}
+<p class="news-card-excerpt">{{ post.description }}</p>
+{% endif %}
+<div class="news-card-meta">
+{{ post.date | date: "%b %d, %Y" }} &middot; {{ read_time }} min read
+</div>
+<a class="stretched-link" href="{{ post.url | relative_url }}"></a>
+</div>
+</div>
+{% endfor %}
+</div>
+
+{% endif %}
+
+</div>

--- a/_pages/start-here.md
+++ b/_pages/start-here.md
@@ -1,0 +1,66 @@
+---
+layout: page
+title: Start Here
+permalink: /start/
+description: Guided learning paths — pick the one that matches you and follow the steps in order.
+nav: true
+nav_order: 2
+---
+
+<div class="row justify-content-center">
+  <div class="col-lg-10">
+
+<p class="page-eyebrow">Guided</p>
+
+<h2>Pick your path</h2>
+
+<p class="learn-intro">The site has 30+ explainers and a half-dozen tools. Without a path, that's a maze. These four routes are sequenced for a specific kind of reader. Pick the closest match — you can switch later.</p>
+
+<div class="learn-grid">
+  {% for path in site.data.learning_paths %}
+  <a class="djb-card djb-card--accent-left path-card" href="#{{ path.id }}">
+    <span class="path-card__icon" aria-hidden="true"><i class="ti ti-{{ path.icon | default: 'route' }}"></i></span>
+    <h3 class="path-card__title">{{ path.title }}</h3>
+    <p class="path-card__audience">{{ path.audience }}</p>
+    <p class="path-card__desc">{{ path.description }}</p>
+    <span class="path-card__cta">Start &rarr;</span>
+  </a>
+  {% endfor %}
+</div>
+
+{% for path in site.data.learning_paths %}
+<section class="learn-path" id="{{ path.id }}">
+  <header class="learn-path__header">
+    <p class="learn-path__audience">{{ path.audience }}</p>
+    <h3 class="learn-path__title">{{ path.title }}</h3>
+    <p class="learn-path__desc">
+      <strong>Goal:</strong> {{ path.goal }}<br>
+      <strong>Time:</strong> {{ path.duration }}
+    </p>
+  </header>
+
+  {% for step in path.steps %}
+  <div class="learn-step">
+    <span class="learn-step__num" aria-hidden="true">{{ forloop.index }}</span>
+    <div class="learn-step__body">
+      <p class="learn-step__kind">{{ step.kind | capitalize }}</p>
+      <h4 class="learn-step__title">
+        {% if step.url %}
+          {% if step.kind == 'external' %}
+          <a href="{{ step.url }}" target="_blank" rel="noopener noreferrer">{{ step.title }} &rarr;</a>
+          {% else %}
+          <a href="{{ step.url | relative_url }}">{{ step.title }}</a>
+          {% endif %}
+        {% else %}
+          {{ step.title }}
+        {% endif %}
+      </h4>
+      {% if step.desc %}<p class="learn-step__desc">{{ step.desc }}</p>{% endif %}
+    </div>
+  </div>
+  {% endfor %}
+</section>
+{% endfor %}
+
+  </div>
+</div>

--- a/_pages/templates.md
+++ b/_pages/templates.md
@@ -1,0 +1,36 @@
+---
+layout: page
+title: Templates
+permalink: /templates/
+description: Practical security artifacts — incident response, vulnerability triage, headers, executive briefings, MFA rollout. Markdown source plus PDF download.
+nav: false
+---
+
+<div class="row justify-content-center">
+  <div class="col-lg-10">
+
+<p class="page-eyebrow">Downloads</p>
+
+<h2>Templates &amp; Checklists</h2>
+
+<p class="learn-intro">Practical artifacts to drop into a runbook, ticket, or board pack. Each template ships as Markdown (copy to clipboard or paste into Confluence/Notion) and as a printable PDF.</p>
+
+<div class="tpl-toc">
+  {% assign sorted_templates = site.templates | sort: "title" %}
+  {% for tpl in sorted_templates %}
+  <article class="djb-card djb-card--accent-left tpl-card">
+    <p class="tpl-card__meta">{{ tpl.category | replace: '-', ' ' | capitalize }}</p>
+    <h3 class="tpl-card__title">{{ tpl.title }}</h3>
+    <p class="tpl-card__desc">{{ tpl.description }}</p>
+    <div class="tpl-card__actions">
+      <a class="btn btn-sm btn-djb-secondary" href="{{ tpl.url | relative_url }}">Open &rarr;</a>
+      <a class="btn btn-sm btn-djb-secondary" href="{{ '/assets/pdf/templates/' | append: tpl.template_slug | append: '.pdf' | relative_url }}" target="_blank" rel="noopener noreferrer">PDF &darr;</a>
+    </div>
+  </article>
+  {% endfor %}
+</div>
+
+<p class="learn-intro" style="margin-top: 2rem;"><strong>Source:</strong> templates are versioned at <a href="https://github.com/djbsec/djbsec.github.io/tree/main/_includes/templates">github.com/djbsec/djbsec.github.io</a>. Spot something to improve? Open an issue or PR.</p>
+
+  </div>
+</div>

--- a/_pages/tools.md
+++ b/_pages/tools.md
@@ -1,16 +1,73 @@
 ---
 layout: page
 title: Tools
+permalink: /tools/
+description: Every tool on the site, grouped by use case — vulnerability management, web security, OSINT, forensics, threat mapping, and AI.
 nav: true
-nav_order: 3
+nav_order: 4
 dropdown: true
 children:
+  - title: All Tools
+    permalink: /tools/
+  - title: divider
   - title: EPSS Scanner
     permalink: /epss/
-  - title: divider
   - title: Blue Team
     permalink: /blue-team/
   - title: divider
   - title: AI Tools & Prompts
     permalink: /ai-tools-prompts/
 ---
+
+<div class="row justify-content-center">
+  <div class="col-lg-10">
+
+<p class="page-eyebrow">Toolkit</p>
+
+<h2>All Tools</h2>
+
+<p class="tools-landing-intro">Every tool on the site, grouped by what it helps you do. Want defender-focused workflow guidance? Start at <a href="{{ '/blue-team/' | relative_url }}">Blue Team</a>. New to security? Try the <a href="{{ '/start/' | relative_url }}">guided learning paths</a>.</p>
+
+<nav class="tools-toc" aria-label="Tool groups">
+  {% for group in site.data.tools %}
+  <a class="tools-toc__chip" href="#{{ group.slug }}">{{ group.group }}</a>
+  {% endfor %}
+</nav>
+
+{% for group in site.data.tools %}
+<section class="tools-group" id="{{ group.slug }}">
+  <header class="tools-group__head">
+    <h3 class="tools-group__title">
+      <i class="ti ti-{{ group.icon | default: 'tool' }}" aria-hidden="true"></i>
+      {{ group.group }}
+    </h3>
+    {% if group.description %}<p class="tools-group__desc">{{ group.description }}</p>{% endif %}
+  </header>
+
+  <div class="tools-grid">
+    {% for tool in group.tools %}
+    <article class="djb-card djb-card--accent-left tools-card tools-card--{{ tool.status | default: 'active' }}">
+      <div class="tools-card__head">
+        <h4 class="djb-card__title tools-card__title">{{ tool.name }}</h4>
+        {% if tool.status == 'planned' %}
+        <span class="chip chip--secondary tools-card__chip">In dev</span>
+        {% endif %}
+      </div>
+      <p class="djb-card__desc tools-card__desc">{{ tool.description }}</p>
+      <div class="tools-card__cta">
+        {% if tool.status == 'planned' %}
+          <em class="text-muted">{{ tool.action | default: 'Coming soon' }}</em>
+        {% elsif tool.external %}
+          <a href="{{ tool.url }}" class="btn btn-sm btn-djb-secondary" target="_blank" rel="noopener noreferrer">{{ tool.action | default: 'Open' }} &rarr;</a>
+        {% else %}
+          <a href="{{ tool.url | relative_url }}" class="btn btn-sm btn-djb-secondary">{{ tool.action | default: 'Launch' }} &rarr;</a>
+        {% endif %}
+      </div>
+    </article>
+    {% endfor %}
+  </div>
+</section>
+{% endfor %}
+
+  </div>
+</div>

--- a/_posts/2026-05-09-fn-building-security-program-from-scratch.md
+++ b/_posts/2026-05-09-fn-building-security-program-from-scratch.md
@@ -1,0 +1,69 @@
+---
+layout: post
+title: "Field Notes — Building a Security Program From Scratch"
+date: 2026-05-09 11:00:00
+description: A 90-day playbook for the first security hire at a small business. Identity, endpoints, email, backups, logging — in that order.
+tags: [Field Notes]
+categories: Field Notes
+thumbnail: assets/img/cybernews.webp
+featured: false
+published: true
+---
+
+You are the first security hire — or you're the IT person who just inherited the security responsibilities. There is no SOC. There is no SIEM. There is one of you and the work of ten.
+
+The trap is to start with the most exciting tool. Don't. Start with the controls that fail loudly when missing.
+
+## The order I always run
+
+### Days 1–14 — Identity
+
+Identity is the perimeter. If you do nothing else, do this:
+
+- App-based MFA on email for everyone. SMS for admins is malpractice in 2026 — use FIDO2 keys or app push with number matching.
+- Disable legacy / basic auth on email (the single biggest BEC mitigation).
+- Audit shared admin accounts. Replace with named accounts and just-in-time elevation.
+- Conditional access: block sign-ins from impossible-travel scenarios.
+
+### Days 15–30 — Endpoints
+
+- Modern EDR on every endpoint. Free options exist; pick one.
+- Disk encryption on every laptop (BitLocker / FileVault).
+- Auto-updates on for OS and major apps.
+- Inventory: a list, even if it's a spreadsheet, of every endpoint and its owner.
+
+### Days 31–45 — Email
+
+- SPF, DKIM, DMARC. DMARC starts in `p=none` (monitor), then `p=quarantine`, then `p=reject` once aligned.
+- Enable phishing-resistant inbound rules: external sender banner, attachment sandbox, link rewriting.
+- Train staff on a 30-minute basics talk. Cover BEC, gift-card scams, and the out-of-band check rule.
+
+### Days 46–60 — Backups
+
+- Pick the systems whose loss would be catastrophic (~5 of them).
+- Tested, off-site, immutable if possible. Restore-test one folder.
+- Document RPO/RTO so leadership knows what they bought.
+
+### Days 61–90 — Logging & Visibility
+
+- Centralized logs from email, IdP, EDR, firewall, cloud control plane. 90 days minimum.
+- Alerts on: privileged-account creation, MFA bypass, mass mailbox forwarding rules, impossible-travel sign-ins.
+- Document one IR playbook (BEC). Tabletop it.
+
+## What I deliberately defer
+
+In the first 90 days, you are not buying a SIEM-of-SIEMs, a SOAR platform, an attack-surface management product, or a deception platform. None of those help you survive a real incident if MFA isn't on email and there's no backup tested in 18 months.
+
+## How to communicate progress
+
+Every two weeks, send leadership three numbers:
+
+1. % of users with MFA on email
+2. % of endpoints with EDR + encryption
+3. Last successful restore test (date)
+
+Three numbers. Improving. That's the whole pitch in the first six months.
+
+## The lesson the books don't say
+
+The hardest part of building a program from scratch is not the technical work. It's saying "no" to shiny tools and "yes" to the unglamorous five-control baseline. Do the boring things first. The boring things are what survive incidents.

--- a/_posts/2026-05-09-fn-prioritizing-vulnerabilities-small-team.md
+++ b/_posts/2026-05-09-fn-prioritizing-vulnerabilities-small-team.md
@@ -1,0 +1,62 @@
+---
+layout: post
+title: "Field Notes — Prioritizing Vulnerabilities in a Small Team"
+date: 2026-05-09 10:00:00
+description: Practitioner notes on triaging a vulnerability backlog without a dedicated AppSec team. CVSS, EPSS, KEV, and the controls already in place.
+tags: [Field Notes]
+categories: Field Notes
+thumbnail: assets/img/cybernews.webp
+featured: false
+published: true
+---
+
+A two-person IT shop opened their scanner one morning to 4,200 "high or critical" findings. Patching all of them in a quarter is not realistic. Patching the 30 that *actually* matter, this week, is.
+
+This is the workflow I land on most often when I help small teams with that pile.
+
+## Three layers of signal
+
+1. **CVSS** — how bad *if* exploited. Public, immediate, often inflated.
+2. **EPSS** — predicted likelihood of exploitation in the next 30 days. Public, updated daily, much closer to reality than CVSS for prioritization.
+3. **CISA KEV** — confirmed evidence of exploitation in the wild. If something is on KEV, it has already happened to someone.
+
+CVSS alone gives you 4,200 critical findings. EPSS narrows that to a few hundred. KEV usually surfaces a few dozen at most across an environment.
+
+## A starting matrix
+
+| Internet-facing | KEV / EPSS > 0.5 | Auth required | Action |
+|---|---|---|---|
+| Yes | Yes | Pre-auth | Emergency change — 24h |
+| Yes | No | Pre-auth | Patch in 7 days |
+| No | Yes | Pre-auth | 14 days |
+| Any | No | Auth | Monthly cycle |
+
+Override the matrix when:
+
+- The host stores something irreplaceable (regulated data, customer secrets).
+- A WAF rule or compensating control is already blocking the attack path.
+- The patch itself has known stability issues — patch only after the next-version is out, but raise the priority of monitoring in the meantime.
+
+## What I track per finding
+
+For every finding I act on, the ticket has the same five fields:
+
+- **Asset(s)** — hostname, owner, criticality
+- **Decision** — patch / mitigate / accept
+- **Justification** — one sentence
+- **Verification** — how we'll know it's fixed (re-scan? runtime check? configuration audit?)
+- **Revisit date** — even "accept" gets a date
+
+Every accepted risk has an expiration. Otherwise the accept-list grows forever and turns into the next breach.
+
+## The 80/20 cheat code
+
+If you do nothing else this week, look at:
+
+1. Anything on CISA KEV that you have running.
+2. Anything internet-facing with EPSS > 0.5.
+3. Anything with a working public exploit, regardless of EPSS.
+
+That's usually under 50 items. It's a manageable Tuesday.
+
+The point is not to ignore the other 4,150 findings. It's to know which ones to do *first* — and to have a defensible answer when leadership asks why you patched X before Y.

--- a/_posts/2026-05-09-fn-reading-epss-scores-in-practice.md
+++ b/_posts/2026-05-09-fn-reading-epss-scores-in-practice.md
@@ -1,0 +1,73 @@
+---
+layout: post
+title: "Field Notes — Reading EPSS Scores in Practice"
+date: 2026-05-09 12:00:00
+description: Working examples of EPSS score interpretation — when to trust it, when to override it, and how it interacts with CVSS and CISA KEV.
+tags: [Field Notes]
+categories: Field Notes
+thumbnail: assets/img/cybernews.webp
+featured: false
+published: true
+---
+
+EPSS is the single best public signal for "how likely is this CVE to actually be exploited?" It's not perfect. It's just dramatically better than CVSS at answering that specific question.
+
+Here's how I read it in real triage.
+
+## What EPSS *is*
+
+A daily-updated probability (0.0 to 1.0) that a given CVE will be exploited in the wild within the next 30 days. The model considers exploit-code availability, mention frequency in security feeds, vendor patching cadence, and observed exploitation telemetry.
+
+You can look up any CVE on the [EPSS Scanner](/epss/) on this site.
+
+## What EPSS *is not*
+
+It is **not** a measure of:
+
+- How bad the exploit is *if* successful (that's CVSS).
+- Whether *your* environment is exposed (that's compensating controls + reachability).
+- Whether the exploit has *already* happened in the wild (that's CISA KEV).
+
+## Reading scores in practice
+
+| EPSS | Interpretation | Default action |
+|------|----------------|----------------|
+| > 0.5 (50%) | High likelihood; security press has it; PoC widely circulating | Patch this cycle, no debate |
+| 0.1 – 0.5 | Working exploit known; selective targeting | Patch within 7–14 days |
+| 0.01 – 0.1 | Some interest; no broad campaign yet | Standard cycle |
+| < 0.01 | Below noise floor for typical attackers | Standard cycle, deprioritize |
+
+**Always override toward action when:**
+
+- The CVE is on CISA KEV (regardless of EPSS).
+- The product is internet-facing AND pre-auth exploitable.
+- A working weaponized exploit is on social media or in a Metasploit module.
+
+**Sometimes override toward deferral when:**
+
+- High EPSS but the affected feature/module is not enabled in our deployment.
+- High EPSS but our WAF/EDR has signatures blocking the attack path.
+- High EPSS but the host is air-gapped.
+
+## The trap I see most often
+
+Teams treat CVSS 9.8 as "drop everything." Most CVSS 9.8 issues never get exploited at scale — they require auth, or a non-default config, or a specific environment. Meanwhile a CVSS 6.5 in CISA KEV with EPSS 0.7 is happening *right now* and is internet-facing on someone's edge router.
+
+Use CVSS to know how bad something *would be*. Use EPSS to know how *likely* it is. Use KEV to know what is *actually happening*. Then add your environmental context to decide what to do about it.
+
+## A worked example
+
+CVE-2024-XXXXX shows up. CVSS 9.8 (RCE, network, no auth). The team panics. I check:
+
+1. **EPSS:** 0.012. Below noise floor.
+2. **KEV:** not listed.
+3. **PoC:** none found on GitHub or X.
+4. **Exposure:** the affected service runs on three internal hosts. None internet-facing.
+
+Decision: patch in the next monthly cycle. Document the rationale. Watch EPSS for the next two weeks — if it climbs past 0.1, escalate.
+
+A week later I check the same CVE: EPSS climbed to 0.34 because a researcher published a working exploit. I bump it forward by two weeks. That's the system working as intended.
+
+## The overall rule
+
+Severity tells you *how bad*. Likelihood tells you *how soon*. Context tells you *what's worth your Tuesday*. Read all three before you patch — and certainly before you skip patching.

--- a/_sass/_learn.scss
+++ b/_sass/_learn.scss
@@ -1,3 +1,390 @@
 // _sass/_learn.scss
-// Learn sub-page styles — filled by Task Group C.
-// This stub exists so main.scss can import it before content is added.
+// Styles for /tools/ landing page and /start/ learning paths.
+
+// =====================================================================
+// Tools landing
+// =====================================================================
+
+.tools-landing-intro {
+  font-size: 0.95rem;
+  color: var(--color-ink-muted);
+  margin-bottom: 1.5rem;
+  line-height: 1.6;
+}
+
+.tools-toc {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0 0 2.25rem;
+  padding: 12px 0;
+  border-top: 1px solid var(--color-surface-border);
+  border-bottom: 1px solid var(--color-surface-border);
+
+  &__chip {
+    font-family: $font-mono;
+    font-size: var(--text-2xs);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--color-ink-muted);
+    border: 1px solid var(--color-surface-border);
+    padding: 5px 10px;
+    border-radius: 999px;
+    transition:
+      border-color 0.12s ease,
+      color 0.12s ease,
+      background 0.12s ease;
+
+    &:hover,
+    &:focus {
+      color: var(--color-accent);
+      border-color: var(--color-accent);
+      background: var(--color-accent-subtle);
+      text-decoration: none;
+    }
+  }
+}
+
+.tools-group {
+  margin-bottom: 2.5rem;
+  scroll-margin-top: 96px;
+
+  &__head {
+    margin-bottom: 0.9rem;
+  }
+  &__title {
+    font-family: $font-display;
+    font-size: 1.25rem;
+    font-weight: 700;
+    margin: 0 0 4px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    letter-spacing: -0.01em;
+
+    i {
+      color: var(--color-accent);
+      font-size: 1.05rem;
+    }
+  }
+  &__desc {
+    font-size: 0.85rem;
+    color: var(--color-ink-muted);
+    margin: 0;
+  }
+}
+
+.tools-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 14px;
+}
+
+.tools-card {
+  display: flex;
+  flex-direction: column;
+
+  &__head {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 10px;
+    margin-bottom: 6px;
+  }
+  &__title {
+    margin: 0;
+    flex: 1;
+  }
+  &__chip {
+    flex-shrink: 0;
+  }
+  &__desc {
+    flex: 1;
+    margin-bottom: 14px;
+  }
+  &__cta {
+    margin-top: auto;
+  }
+
+  &--planned {
+    opacity: 0.78;
+  }
+}
+
+// =====================================================================
+// Start Here / Learning Paths
+// =====================================================================
+
+.learn-intro {
+  font-size: 1rem;
+  color: var(--color-ink-muted);
+  margin-bottom: 2rem;
+  line-height: 1.65;
+}
+
+.learn-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+  margin-bottom: 2.5rem;
+}
+
+.path-card {
+  display: flex;
+  flex-direction: column;
+
+  &__icon {
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
+    background: var(--color-accent-subtle);
+    color: var(--color-accent);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 12px;
+    font-size: 1.05rem;
+  }
+  &__title {
+    font-family: $font-display;
+    font-size: 1.05rem;
+    font-weight: 700;
+    margin: 0 0 4px;
+    color: var(--color-ink);
+    letter-spacing: -0.01em;
+  }
+  &__audience {
+    font-family: $font-mono;
+    font-size: var(--text-2xs);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-ink-muted);
+    margin-bottom: 8px;
+  }
+  &__desc {
+    font-size: 0.85rem;
+    color: var(--color-ink-muted);
+    line-height: 1.55;
+    margin-bottom: 12px;
+    flex: 1;
+  }
+  &__cta {
+    font-family: $font-mono;
+    font-size: var(--text-xs);
+    letter-spacing: 0.04em;
+    color: var(--color-accent);
+    margin-top: auto;
+  }
+}
+
+.learn-path {
+  border: 1px solid var(--color-surface-border);
+  border-radius: 8px;
+  background: var(--color-surface);
+  padding: 24px 24px 8px;
+  margin-bottom: 1.75rem;
+  scroll-margin-top: 96px;
+
+  &__header {
+    border-bottom: 1px dashed var(--color-surface-border);
+    padding-bottom: 16px;
+    margin-bottom: 18px;
+  }
+  &__title {
+    font-family: $font-display;
+    font-size: 1.4rem;
+    font-weight: 700;
+    margin: 0 0 6px;
+    letter-spacing: -0.015em;
+  }
+  &__audience {
+    font-family: $font-mono;
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-accent);
+    margin-bottom: 10px;
+  }
+  &__desc {
+    font-size: 0.92rem;
+    color: var(--color-ink-muted);
+    line-height: 1.6;
+    margin: 0;
+  }
+}
+
+.learn-step {
+  display: grid;
+  grid-template-columns: 36px 1fr;
+  gap: 14px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--color-surface-border);
+
+  &:last-child {
+    border-bottom: 0;
+  }
+
+  &__num {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: var(--color-accent);
+    color: #fff;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-family: $font-mono;
+    font-size: var(--text-xs);
+    font-weight: 600;
+  }
+  &__body {
+    min-width: 0;
+  }
+  &__kind {
+    font-family: $font-mono;
+    font-size: var(--text-2xs);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-ink-muted);
+    margin-bottom: 2px;
+  }
+  &__title {
+    font-family: $font-display;
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 0 0 4px;
+    a {
+      color: var(--color-ink);
+      &:hover {
+        color: var(--color-accent);
+      }
+    }
+  }
+  &__desc {
+    font-size: 0.85rem;
+    color: var(--color-ink-muted);
+    margin: 0;
+    line-height: 1.55;
+  }
+}
+
+// =====================================================================
+// Templates
+// =====================================================================
+
+.tpl-toc {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 14px;
+  margin-bottom: 2rem;
+}
+
+.tpl-card {
+  display: flex;
+  flex-direction: column;
+
+  &__title {
+    font-family: $font-display;
+    font-size: 1rem;
+    font-weight: 700;
+    margin: 0 0 6px;
+    color: var(--color-ink);
+  }
+  &__desc {
+    font-size: 0.83rem;
+    color: var(--color-ink-muted);
+    line-height: 1.55;
+    flex: 1;
+    margin-bottom: 12px;
+  }
+  &__meta {
+    font-family: $font-mono;
+    font-size: var(--text-2xs);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-ink-muted);
+    margin-bottom: 10px;
+  }
+  &__actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-top: auto;
+  }
+}
+
+.tpl-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  align-items: center;
+  margin: 1rem 0 1.5rem;
+  padding: 12px 14px;
+  border: 1px dashed var(--color-surface-border);
+  border-radius: 6px;
+  background: var(--color-surface);
+}
+
+.tpl-copy-feedback {
+  font-size: var(--text-xs);
+  color: var(--color-accent);
+  letter-spacing: 0.04em;
+}
+
+// =====================================================================
+// Subscribe CTA
+// =====================================================================
+
+.subscribe-cta {
+  border: 1px solid var(--color-surface-border);
+  border-radius: 8px;
+  padding: 22px 24px;
+  background: var(--color-surface);
+  margin: 2rem 0 1rem;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 16px;
+  align-items: center;
+
+  @media (max-width: 720px) {
+    grid-template-columns: 1fr;
+  }
+
+  &__title {
+    font-family: $font-display;
+    font-size: 1.1rem;
+    font-weight: 700;
+    margin: 0 0 4px;
+    letter-spacing: -0.01em;
+  }
+  &__desc {
+    font-size: 0.85rem;
+    color: var(--color-ink-muted);
+    margin: 0;
+  }
+  &__actions {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+  &__newsletter {
+    margin-top: 14px;
+    grid-column: 1 / -1;
+    border-top: 1px dashed var(--color-surface-border);
+    padding-top: 14px;
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+
+    input[type="email"] {
+      flex: 1;
+      min-width: 220px;
+      padding: 8px 12px;
+      border: 1px solid var(--color-surface-border);
+      border-radius: 4px;
+      background: var(--color-surface-raised, var(--color-surface));
+      color: var(--color-ink);
+      font-size: 0.85rem;
+    }
+  }
+}

--- a/_templates/executive-cyber-briefing.md
+++ b/_templates/executive-cyber-briefing.md
@@ -1,0 +1,20 @@
+---
+layout: page
+title: Executive Cyber Briefing
+permalink: /templates/executive-cyber-briefing/
+description: Two-page monthly or quarterly cybersecurity briefing template for non-technical executives, board members, and business owners.
+category: governance
+template_slug: executive-cyber-briefing
+---
+
+<div class="tpl-actions">
+  <a class="btn btn-sm btn-djb-secondary" href="{{ '/assets/pdf/templates/executive-cyber-briefing.pdf' | relative_url }}" target="_blank" rel="noopener noreferrer">Download PDF &darr;</a>
+  <button class="btn btn-sm btn-djb-secondary" type="button" data-tpl-copy>Copy as Markdown</button>
+  <span class="tpl-copy-feedback mono" data-tpl-copy-feedback></span>
+</div>
+
+{% capture md %}{% include templates/executive-cyber-briefing.md %}{% endcapture %}
+{{ md | markdownify }}
+<textarea hidden id="tpl-md-source" readonly>{{ md }}</textarea>
+
+<script defer src="{{ '/assets/js/template-copy.js' | relative_url }}"></script>

--- a/_templates/incident-response-checklist.md
+++ b/_templates/incident-response-checklist.md
@@ -1,0 +1,20 @@
+---
+layout: page
+title: Incident Response Checklist
+permalink: /templates/incident-response-checklist/
+description: Working checklist for the SANS / NIST PICERL incident response lifecycle — preparation, identification, containment, eradication, recovery, lessons learned.
+category: incident-response
+template_slug: incident-response-checklist
+---
+
+<div class="tpl-actions">
+  <a class="btn btn-sm btn-djb-secondary" href="{{ '/assets/pdf/templates/incident-response-checklist.pdf' | relative_url }}" target="_blank" rel="noopener noreferrer">Download PDF &darr;</a>
+  <button class="btn btn-sm btn-djb-secondary" type="button" data-tpl-copy>Copy as Markdown</button>
+  <span class="tpl-copy-feedback mono" data-tpl-copy-feedback></span>
+</div>
+
+{% capture md %}{% include templates/incident-response-checklist.md %}{% endcapture %}
+{{ md | markdownify }}
+<textarea hidden id="tpl-md-source" readonly>{{ md }}</textarea>
+
+<script defer src="{{ '/assets/js/template-copy.js' | relative_url }}"></script>

--- a/_templates/mfa-rollout-checklist.md
+++ b/_templates/mfa-rollout-checklist.md
@@ -1,0 +1,20 @@
+---
+layout: page
+title: MFA Rollout Checklist
+permalink: /templates/mfa-rollout-checklist/
+description: Phased MFA rollout plan — privileged accounts, identity provider, VPN, SaaS, and customer-facing apps — with factor priorities, common pitfalls, and maintenance cadence.
+category: identity
+template_slug: mfa-rollout-checklist
+---
+
+<div class="tpl-actions">
+  <a class="btn btn-sm btn-djb-secondary" href="{{ '/assets/pdf/templates/mfa-rollout-checklist.pdf' | relative_url }}" target="_blank" rel="noopener noreferrer">Download PDF &darr;</a>
+  <button class="btn btn-sm btn-djb-secondary" type="button" data-tpl-copy>Copy as Markdown</button>
+  <span class="tpl-copy-feedback mono" data-tpl-copy-feedback></span>
+</div>
+
+{% capture md %}{% include templates/mfa-rollout-checklist.md %}{% endcapture %}
+{{ md | markdownify }}
+<textarea hidden id="tpl-md-source" readonly>{{ md }}</textarea>
+
+<script defer src="{{ '/assets/js/template-copy.js' | relative_url }}"></script>

--- a/_templates/security-headers-checklist.md
+++ b/_templates/security-headers-checklist.md
@@ -1,0 +1,20 @@
+---
+layout: page
+title: HTTP Security Headers Checklist
+permalink: /templates/security-headers-checklist/
+description: Production-ready checklist of HTTP security headers — HSTS, CSP, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, cookie flags, and headers to remove.
+category: web-security
+template_slug: security-headers-checklist
+---
+
+<div class="tpl-actions">
+  <a class="btn btn-sm btn-djb-secondary" href="{{ '/assets/pdf/templates/security-headers-checklist.pdf' | relative_url }}" target="_blank" rel="noopener noreferrer">Download PDF &darr;</a>
+  <button class="btn btn-sm btn-djb-secondary" type="button" data-tpl-copy>Copy as Markdown</button>
+  <span class="tpl-copy-feedback mono" data-tpl-copy-feedback></span>
+</div>
+
+{% capture md %}{% include templates/security-headers-checklist.md %}{% endcapture %}
+{{ md | markdownify }}
+<textarea hidden id="tpl-md-source" readonly>{{ md }}</textarea>
+
+<script defer src="{{ '/assets/js/template-copy.js' | relative_url }}"></script>

--- a/_templates/vulnerability-triage-worksheet.md
+++ b/_templates/vulnerability-triage-worksheet.md
@@ -1,0 +1,20 @@
+---
+layout: page
+title: Vulnerability Triage Worksheet
+permalink: /templates/vulnerability-triage-worksheet/
+description: Worksheet for triaging a CVE — severity inputs, exposure questions, compensating controls, and a decision matrix that combines CVSS, EPSS, and CISA KEV.
+category: vulnerability-management
+template_slug: vulnerability-triage-worksheet
+---
+
+<div class="tpl-actions">
+  <a class="btn btn-sm btn-djb-secondary" href="{{ '/assets/pdf/templates/vulnerability-triage-worksheet.pdf' | relative_url }}" target="_blank" rel="noopener noreferrer">Download PDF &darr;</a>
+  <button class="btn btn-sm btn-djb-secondary" type="button" data-tpl-copy>Copy as Markdown</button>
+  <span class="tpl-copy-feedback mono" data-tpl-copy-feedback></span>
+</div>
+
+{% capture md %}{% include templates/vulnerability-triage-worksheet.md %}{% endcapture %}
+{{ md | markdownify }}
+<textarea hidden id="tpl-md-source" readonly>{{ md }}</textarea>
+
+<script defer src="{{ '/assets/js/template-copy.js' | relative_url }}"></script>

--- a/assets/js/template-copy.js
+++ b/assets/js/template-copy.js
@@ -1,0 +1,50 @@
+(function () {
+  function setFeedback(el, text) {
+    if (!el) return;
+    el.textContent = text;
+    setTimeout(function () {
+      el.textContent = "";
+    }, 2200);
+  }
+
+  document.addEventListener("click", function (e) {
+    var btn = e.target.closest("[data-tpl-copy]");
+    if (!btn) return;
+    var src = document.getElementById("tpl-md-source");
+    var feedback = document.querySelector("[data-tpl-copy-feedback]");
+    if (!src) {
+      setFeedback(feedback, "Source unavailable");
+      return;
+    }
+    var text = src.value || src.textContent || "";
+    if (!text) {
+      setFeedback(feedback, "Empty source");
+      return;
+    }
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(
+        function () {
+          setFeedback(feedback, "Copied " + text.length + " chars");
+        },
+        function () {
+          setFeedback(feedback, "Copy blocked — select & copy manually");
+        }
+      );
+    } else {
+      var ta = document.createElement("textarea");
+      ta.value = text;
+      ta.setAttribute("readonly", "");
+      ta.style.position = "absolute";
+      ta.style.left = "-9999px";
+      document.body.appendChild(ta);
+      ta.select();
+      try {
+        document.execCommand("copy");
+        setFeedback(feedback, "Copied");
+      } catch (err) {
+        setFeedback(feedback, "Copy failed");
+      }
+      document.body.removeChild(ta);
+    }
+  });
+})();


### PR DESCRIPTION
Codex strategic features B1–B5 in a single bundle:

- B1 Tools landing (/tools/) — _data/tools.yml drives grouped cards; dropdown nav preserved with new "All Tools" entry.
- B2 Start Here (/start/) — four persona learning paths sequencing existing _explained articles + tools.
- B3 Templates collection — five working artifacts (IR checklist, vuln triage, security headers, exec briefing, MFA rollout) with Copy-as-Markdown and PDF download. PDF step added to deploy.yml, push-only and continue-on-error.
- B4 Field Notes (/field-notes/) — filtered post index plus three starter posts (small-team vuln prio, building program from scratch, reading EPSS in practice).
- B5 Subscribe CTA — RSS + socials include rendered on home and cybernews. Newsletter form gated on site.newsletter.enabled (off until Loops.so endpoint provided).

Nav re-ordered: Home → Blog → Start Here → CyberNews → Tools → Learn → Calendar. JEKYLL_ENV=production build clean.