### PR TITLE
Add public Roadmap page

### DIFF
--- a/_data/roadmap.yml
+++ b/_data/roadmap.yml
@@ -1,0 +1,107 @@
+# Public roadmap data — drives _pages/roadmap.md
+#
+# SECURITY: This file is PUBLIC. Keep it to user-facing feature descriptions only.
+# Do NOT add: branch names, file paths, server/worker hostnames, API keys or secrets,
+# internal infrastructure, security-audit findings, or any PII. The private working
+# backlog lives in .gsd/ (gitignored) — this is the sanitized, outward-facing view.
+#
+# status values for planned[]: "in-progress" | "planned"
+
+updated: "June 2026"
+
+planned:
+  - title: Log Analyzer
+    status: in-progress
+    area: Blue Team
+    description: >-
+      A browser-based tool to parse common log formats — web server access logs,
+      syslog, and EDR exports — and surface suspicious patterns and indicators of
+      compromise. Runs entirely in your browser, so log data never leaves your machine.
+
+  - title: Richer Hash Lookup threat intel
+    status: planned
+    area: Tools
+    link: /tools/hash-lookup/
+    description: >-
+      Extend the Hash Lookup tool with multi-engine antivirus detection ratios and
+      malware family labels alongside the existing known-file reputation data.
+
+  - title: Conference travel cost estimator
+    status: planned
+    area: Calendar
+    link: /cybersecurity-calendar/
+    description: >-
+      Pick your home airport in the conference calendar to see tailored airfare and
+      total-cost estimates for each event.
+
+  - title: Comments on CyberNews posts
+    status: planned
+    area: Blog
+    link: /cybernews/
+    description: >-
+      Enable threaded discussion on the daily CyberNews posts so readers can weigh in
+      and ask questions.
+
+shipped:
+  - title: CVSS 4.0 in the EPSS tool
+    date: "June 2026"
+    area: Tools
+    link: /epss/
+    description: >-
+      The EPSS CVE lookup now shows the CVSS 4.0 base score and severity (with the full
+      vector on hover) alongside the existing CVSS v2 and v3 scores.
+
+  - title: AI Plugin Security Radar
+    date: "June 2026"
+    area: Tools
+    link: /plugins/
+    description: >-
+      An interactive dashboard reviewing the security posture of popular AI plugins —
+      searchable and filterable, with per-plugin findings and rationale.
+
+  - title: Security templates & downloads
+    date: "May 2026"
+    area: Resources
+    link: /templates/
+    description: >-
+      A collection of ready-to-use checklists and worksheets — incident response,
+      vulnerability triage, MFA rollout, and more — each downloadable and copy-ready.
+
+  - title: Guided learning paths
+    date: "May 2026"
+    area: Learn
+    link: /start/
+    description: >-
+      A "Start Here" page with curated, step-by-step learning paths for newcomers,
+      blue-team analysts, IT leaders, and small-business owners.
+
+  - title: Tools landing page
+    date: "May 2026"
+    area: Tools
+    link: /tools/
+    description: >-
+      Every tool on the site, grouped by what it helps you do — vulnerability management,
+      web security, OSINT, forensics, and AI.
+
+  - title: Field Notes
+    date: "May 2026"
+    area: Blog
+    link: /field-notes/
+    description: >-
+      Practitioner write-ups on real-world security work — prioritizing vulnerabilities
+      on a small team, building a program from scratch, and reading EPSS in practice.
+
+  - title: Hash Lookup tool
+    date: "April 2026"
+    area: Blue Team
+    link: /tools/hash-lookup/
+    description: >-
+      Look up the reputation of a file by its MD5, SHA-1, or SHA-256 hash, with
+      one-click pivots to VirusTotal, MalwareBazaar, and Hybrid Analysis.
+
+  - title: Site design refresh
+    date: "April 2026"
+    area: Site
+    description: >-
+      A site-wide visual pass — consistent color and type system, refined cards, and
+      improved light and dark themes.

--- a/_pages/roadmap.md
+++ b/_pages/roadmap.md
@@ -1,0 +1,79 @@
+---
+layout: page
+title: Roadmap
+permalink: /roadmap/
+description: What's been shipped and what's on the backlog — a public view of where this site is headed.
+nav: true
+nav_order: 7
+---
+
+<div class="row">
+  <div class="col-12">
+
+<p class="page-eyebrow">Roadmap</p>
+
+<h2>What's shipped & what's next</h2>
+
+<p class="tools-landing-intro">A public view of the backlog. Below is what's currently in progress or planned, followed by a log of what's already shipped. Last updated {{ site.data.roadmap.updated }}.</p>
+
+<section class="roadmap-section" aria-labelledby="roadmap-planned">
+  <h3 id="roadmap-planned" class="tools-group__title" style="margin-top: 8px;">
+    <i class="ti ti-list-check" aria-hidden="true"></i> On the backlog
+  </h3>
+
+  <div class="tools-grid">
+    {% for item in site.data.roadmap.planned %}
+    <article class="djb-card djb-card--accent-left">
+      <div class="tools-card__head">
+        <h4 class="djb-card__title">{{ item.title | escape }}</h4>
+        {% if item.status == 'in-progress' %}
+        <span class="chip" style="background: var(--color-severity-high); color: var(--color-surface);">In progress</span>
+        {% else %}
+        <span class="chip chip--secondary">Planned</span>
+        {% endif %}
+      </div>
+      <p class="djb-card__desc">{{ item.description | escape }}</p>
+      {% if item.area or item.link %}
+      <div class="tools-card__cta">
+        {% if item.area %}<span class="chip chip--secondary">{{ item.area | escape }}</span>{% endif %}
+        {% if item.link %}<a href="{{ item.link | relative_url }}" class="btn btn-sm btn-djb-secondary" style="margin-left: 8px;">Related &rarr;</a>{% endif %}
+      </div>
+      {% endif %}
+    </article>
+    {% endfor %}
+  </div>
+</section>
+
+<section class="roadmap-section" aria-labelledby="roadmap-shipped" style="margin-top: 40px;">
+  <h3 id="roadmap-shipped" class="tools-group__title">
+    <i class="ti ti-check" aria-hidden="true"></i> Shipped
+  </h3>
+
+  <div class="table-responsive">
+    <table class="table table-hover page-token-table mb-0">
+      <thead class="thead-dark">
+        <tr>
+          <th style="width: 14%;">When</th>
+          <th style="width: 24%;">Feature</th>
+          <th style="width: 50%;">What it does</th>
+          <th style="width: 12%;">Link</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for item in site.data.roadmap.shipped %}
+        <tr>
+          <td><span class="chip" style="background: var(--color-severity-low); color: var(--color-surface);">{{ item.date | escape }}</span></td>
+          <td><strong>{{ item.title | escape }}</strong>{% if item.area %}<br><span class="chip chip--secondary">{{ item.area | escape }}</span>{% endif %}</td>
+          <td>{{ item.description | escape }}</td>
+          <td>
+            {% if item.link %}<a href="{{ item.link | relative_url }}" class="btn btn-sm btn-djb-secondary">View</a>{% else %}<span class="text-muted">&mdash;</span>{% endif %}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- New `/roadmap/` page in the top nav (nav_order 7) showing the public backlog and a log of shipped features
- Driven by a new curated data file `_data/roadmap.yml` — **planned/in-progress** items render as status-chipped cards, **shipped** items as a dated table
- Matches existing site patterns (`.djb-card`, `.chip`, `page-token-table`); status colors use existing CSS tokens so they survive PurgeCSS and follow light/dark themes

## Security / privacy
The data file is a deliberately **sanitized, outward-facing view**. It contains only user-facing feature descriptions — **no** branch names, file paths, server/worker hostnames, API keys, secrets, internal infrastructure, security-audit findings, or PII. The private working backlog stays in gitignored `.gsd/`. A header comment in `_data/roadmap.yml` documents this rule for future edits.

Verified the generated `_site/roadmap/index.html` has zero matches for tokens, `*.workers.dev`/`*.onrender.com` hostnames, `wrangler`/secret references, email/PII, `SEC-*` audit IDs, or internal file paths.

## Testing
- `JEKYLL_ENV=production bundle exec jekyll build` passes
- Playwright on built site: 4 planned cards, 8 shipped rows, Roadmap nav link visible, zero console errors; light-mode screenshot reviewed
- Secret/PII grep on output HTML: 0 hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)